### PR TITLE
Fix getstringArray function return obj

### DIFF
--- a/src/gameClasses/components/script/VariableComponent.js
+++ b/src/gameClasses/components/script/VariableComponent.js
@@ -1645,6 +1645,9 @@ var VariableComponent = TaroEntity.extend({
 							console.error(err);
 						}
 						returnValue = array[index];
+						if (typeof returnValue == 'object') {
+							returnValue = JSON.stringify(returnValue);
+						}
 					}
 					break;
 


### PR DESCRIPTION
It is not very reasonable to return an array or object to player as player passed a string to it.
This caused you cannot get nested array value by get..(get...thing))
Thats why its inconvenience.
With the fix, player should get json stringify value if the return value is non string or number and they can get nested array easily

Example
![image](https://github.com/moddio/taro2/assets/62375288/73caa7b0-c4e3-4b79-8dd2-d4812760b345)
Current

![image](https://github.com/moddio/taro2/assets/62375288/8de22455-95b9-49ae-86a3-71bfdede7ba3)
After
