### PR TITLE
Change eraser's (aka TileEditor's emptyTile method) to set the tile index of an area to 0 instead of -1

### DIFF
--- a/ts/src/renderer/phaser/classes/devmode/DevModeTools.ts
+++ b/ts/src/renderer/phaser/classes/devmode/DevModeTools.ts
@@ -378,7 +378,7 @@ class DevModeTools extends Phaser.GameObjects.Container {
 	emptyTile(): void {
 		if (!this.modeButtons[3].active) {
 			this.tileEditor.lastSelectedTileArea = this.tileEditor.selectedTileArea;
-			this.tileEditor.selectedTileArea = { 0: { 0: -1 } };
+			this.tileEditor.selectedTileArea = { 0: { 0: 0 } };
 			this.tileEditor.activateMarkers(true);
 			this.entityEditor.activatePlacement(false);
 			this.scene.regionEditor.regionTool = false;


### PR DESCRIPTION
Using eraser right now completely breaks the map and the game itself, as taro engine throws a type error of `t.tiles[i.index]` being undefined if the tile index is outside of a tilesheet tile quantity.