### PR TITLE
Projectile stream mode

### DIFF
--- a/engine/components/network/net.io/TaroNetIoClient.js
+++ b/engine/components/network/net.io/TaroNetIoClient.js
@@ -485,7 +485,7 @@ var TaroNetIoClient = {
 						// update each entities' final position, so player knows where everything are when returning from a different browser tab
 						// we are not executing this in taroEngine or taroEntity, becuase they don't execute when browser tab is inactive
 						var entity = taro.$(entityId);
-						if (entity._category === 'projectile') console.log(entity._stats.name, entityData);
+
 						if (entity && entityData[3]) {
 							entity.teleportTo(entityData[0], entityData[1], entityData[2]);
 						}
@@ -493,8 +493,7 @@ var TaroNetIoClient = {
 						// instead, we'll use position updated by physics engine
 						else if (taro.game.cspEnabled && entity &&
 							entity.finalKeyFrame[0] < newSnapshotTimestamp &&
-							entity != taro.client.selectedUnit &&
-							!entity._stats.streamMode
+							entity != taro.client.selectedUnit
 						) {
 							entity.finalKeyFrame = [newSnapshotTimestamp, obj[entityId]];
 						}

--- a/engine/components/network/net.io/TaroNetIoClient.js
+++ b/engine/components/network/net.io/TaroNetIoClient.js
@@ -485,6 +485,7 @@ var TaroNetIoClient = {
 						// update each entities' final position, so player knows where everything are when returning from a different browser tab
 						// we are not executing this in taroEngine or taroEntity, becuase they don't execute when browser tab is inactive
 						var entity = taro.$(entityId);
+						if (entity._category === 'projectile') console.log(entity._stats.name, entityData);
 						if (entity && entityData[3]) {
 							entity.teleportTo(entityData[0], entityData[1], entityData[2]);
 						}
@@ -492,7 +493,8 @@ var TaroNetIoClient = {
 						// instead, we'll use position updated by physics engine
 						else if (taro.game.cspEnabled && entity &&
 							entity.finalKeyFrame[0] < newSnapshotTimestamp &&
-							entity != taro.client.selectedUnit
+							entity != taro.client.selectedUnit &&
+							!entity._stats.streamMode
 						) {
 							entity.finalKeyFrame = [newSnapshotTimestamp, obj[entityId]];
 						}

--- a/engine/components/physics/box2d/Box2dComponent.js
+++ b/engine/components/physics/box2d/Box2dComponent.js
@@ -651,10 +651,8 @@ var PhysicsComponent = TaroEventingClass.extend({
 										entity.finalKeyFrame= [taro._currentTime, [x, y, angle]];
 									}
 									// projectiles don't use server-streamed position
-									else if (entity._category == 'projectile' &&
-										entity._stats.sourceItemId != undefined && !entity._streamMode
+									else if (entity._category == 'projectile' && !entity._stats.streamMode
 									) {
-										console.log(entity._stats.name);
 										entity.prevPhysicsFrame = entity.nextPhysicsFrame;
 										entity.nextPhysicsFrame = [nextFrameTime, [x, y, angle]];
 									} else { // update server-streamed entities' body position
@@ -664,6 +662,7 @@ var PhysicsComponent = TaroEventingClass.extend({
 									}
 								}
 							}
+
 
 							entity.body.setPosition({ x: x / entity._b2dRef._scaleRatio, y: y / entity._b2dRef._scaleRatio });
 							entity.body.setAngle(angle);

--- a/engine/components/physics/box2d/Box2dComponent.js
+++ b/engine/components/physics/box2d/Box2dComponent.js
@@ -654,6 +654,7 @@ var PhysicsComponent = TaroEventingClass.extend({
 									else if (entity._category == 'projectile' &&
 										entity._stats.sourceItemId != undefined && !entity._streamMode
 									) {
+										console.log(entity._stats.name);
 										entity.prevPhysicsFrame = entity.nextPhysicsFrame;
 										entity.nextPhysicsFrame = [nextFrameTime, [x, y, angle]];
 									} else { // update server-streamed entities' body position

--- a/engine/components/physics/box2d/Box2dComponent.js
+++ b/engine/components/physics/box2d/Box2dComponent.js
@@ -559,7 +559,6 @@ var PhysicsComponent = TaroEventingClass.extend({
 			} else {
 				self._world.step(timeElapsedSinceLastStep / 1000, 8, 3); // Call the world step; frame-rate, velocity iterations, position iterations
 				let nextFrameTime = taro._currentTime + (1000 / taro._gameLoopTickRate) - 10; // 10ms is to give extra buffer to prepare for the next frame
-				
 				var tempBod = self._world.getBodyList();
 
 				// iterate through every physics body
@@ -580,7 +579,7 @@ var PhysicsComponent = TaroEventingClass.extend({
 							// ) {
 							// 	var angle = Math.atan2(tempBod.m_linearVelocity.y, tempBod.m_linearVelocity.x) + Math.PI / 2;
 							// } else {
-								var angle = tempBod.getAngle();
+							var angle = tempBod.getAngle();
 							// }
 
 							var tileWidth = taro.scaleMapDetails.tileWidth;
@@ -601,12 +600,12 @@ var PhysicsComponent = TaroEventingClass.extend({
 								// fire 'touchesWall' trigger when unit goes out of bounds for the first time
 								if (!entity.isOutOfBounds) {
 									if (entity._category == 'unit' || entity._category == 'item' || entity._category == 'projectile') {
-										entity.script.trigger("entityTouchesWall");
+										entity.script.trigger('entityTouchesWall');
 									}
 
 									if (entity._category == 'unit') {
 										// console.log("unitTouchesWall", entity.id());
-										taro.script.trigger('unitTouchesWall', { unitId: entity.id() });										
+										taro.script.trigger('unitTouchesWall', { unitId: entity.id() });
 									} else if (entity._category == 'item') {
 										taro.script.trigger('itemTouchesWall', { itemId: entity.id() });
 									} else if (entity._category == 'projectile') {
@@ -626,13 +625,12 @@ var PhysicsComponent = TaroEventingClass.extend({
 							// entity just has teleported
 							if (entity.teleportDestination != undefined && entity.teleported) {
 								entity.finalKeyFrame[1] = entity.teleportDestination;
-								x = entity.teleportDestination[0]
-								y = entity.teleportDestination[1]
-								angle = entity.teleportDestination[2]
+								x = entity.teleportDestination[0];
+								y = entity.teleportDestination[1];
+								angle = entity.teleportDestination[2];
 								entity.teleportDestination = undefined;
 							} else {
 								if (taro.isServer) {
-									
 									/* server-side reconciliation */
 									// hard-correct client entity's position (teleport) if the distance between server & client is greater than 100px
 									// continuously for 10 frames in a row
@@ -642,7 +640,7 @@ var PhysicsComponent = TaroEventingClass.extend({
 										var xDiff = targetX - x;
 										var yDiff = targetY - y;
 										x += xDiff/2;
-										y += yDiff/2;									
+										y += yDiff/2;
 									}
 
 									entity.translateTo(x, y, 0);
@@ -653,22 +651,21 @@ var PhysicsComponent = TaroEventingClass.extend({
 										entity.finalKeyFrame= [taro._currentTime, [x, y, angle]];
 									}
 									// projectiles don't use server-streamed position
-									else if (entity._category == 'projectile' && 
+									else if (entity._category == 'projectile' &&
 										entity._stats.sourceItemId != undefined && !entity._streamMode
 									) {
 										entity.prevPhysicsFrame = entity.nextPhysicsFrame;
 										entity.nextPhysicsFrame = [nextFrameTime, [x, y, angle]];
 									} else { // update server-streamed entities' body position
-										x = entity.finalKeyFrame[1][0]
-										y = entity.finalKeyFrame[1][1]
-										angle = entity.finalKeyFrame[1][2]
+										x = entity.finalKeyFrame[1][0];
+										y = entity.finalKeyFrame[1][1];
+										angle = entity.finalKeyFrame[1][2];
 									}
-								}	
+								}
 							}
 
 							entity.body.setPosition({ x: x / entity._b2dRef._scaleRatio, y: y / entity._b2dRef._scaleRatio });
 							entity.body.setAngle(angle);
-							
 
 							if (tempBod.asleep) {
 								// The tempBod was asleep last frame, fire an awake event

--- a/engine/core/TaroEntity.js
+++ b/engine/core/TaroEntity.js
@@ -1980,6 +1980,7 @@ var TaroEntity = TaroObject.extend({
 				} else if (type == 'attacked') {
 					this.streamUpdateData([{ effect: {type: type, data: data} }]);
 				}
+				// playEffect projectile creation is only happening on the client;
 
 			} else if (taro.isClient) {
 
@@ -2011,13 +2012,13 @@ var TaroEntity = TaroObject.extend({
 				}
 
 				if (effect.projectileType) {
+					// these are never created on the server
 					var projectile = taro.game.getAsset('projectileTypes', effect.projectileType);
 
 					if (projectile) {
 						var position = taro.game.lastProjectileHitPosition ||
 							(this.body && this.body.getPosition()) ||
 							this._translate;
-
 						if (this.body) {
 							position.x *= this._b2dRef._scaleRatio;
 							position.y *= this._b2dRef._scaleRatio;
@@ -2033,6 +2034,8 @@ var TaroEntity = TaroObject.extend({
 						};
 						//fix added for correct phaser projectile texture
 						projectile.type = effect.projectileType;
+						// set property for client-only effect projectiles
+						projectile.streamMode = 0;
 						new Projectile(projectile);
 					}
 				}
@@ -4249,7 +4252,7 @@ var TaroEntity = TaroObject.extend({
 								break;
 							case 'effect':
 								// don't use streamed effect call for my own unit or its items
-								if (newValue.type != 'attacked' && 
+								if (newValue.type != 'attacked' &&
 									(this == taro.client.selectedUnit ||
 									(this._category == 'item' && this.getOwnerUnit() == taro.client.selectedUnit))
 								) {
@@ -5130,9 +5133,7 @@ var TaroEntity = TaroObject.extend({
 				yDiff = (finalTransform[1] - y);
 				x = x + xDiff / 10;
 	        	y = y + yDiff / 10;
-				if (this._category === 'projectile') console.log(this._stats.name, this._stats.streamMode);
 	        }
-			else if (this._category === 'projectile') console.log(this._stats.name, this._stats.streamMode);
 
 	        if (
 	        	// interpolate item rotation
@@ -5149,9 +5150,9 @@ var TaroEntity = TaroObject.extend({
 	        	rotate = this.interpolateValue(rotateStart, rotateEnd, taro._currentTime - 16, taro._currentTime, taro._currentTime + 16);
 	        }
 		} else { // use server-streamed keyFrames
-			if (this._category === 'projectile') console.log(taro.nextSnapshot, taro.nextSnapshot[1][this.id()], taro.prevSnapshot[1][this.id()]);
 			if (taro.nextSnapshot) {
 				var nextTransform = taro.nextSnapshot[1][this.id()];
+
 				if (nextTransform) {
 					nextKeyFrame = [taro.nextSnapshot[0], nextTransform];
 

--- a/engine/core/TaroEntity.js
+++ b/engine/core/TaroEntity.js
@@ -5092,11 +5092,11 @@ var TaroEntity = TaroObject.extend({
 			this._lastTransformAt == taro._currentTime ||
 			// entity has no body
 			this._translate == undefined ||
-			this._stats.currentBody == undefined ||			
+			this._stats.currentBody == undefined ||
 			(
 				// ignore server stream of my own unit's sprite-only item
-				this._stats.currentBody && this._stats.currentBody.type == 'spriteOnly' && 
-				(this.getOwnerUnit && this.getOwnerUnit() == taro.client.selectedUnit) 
+				this._stats.currentBody && this._stats.currentBody.type == 'spriteOnly' &&
+				(this.getOwnerUnit && this.getOwnerUnit() == taro.client.selectedUnit)
 			)
 		) {
 			return;
@@ -5111,7 +5111,7 @@ var TaroEntity = TaroObject.extend({
 		let yDiff = null;
 		let rotateStart = null;
 		let rotateEnd = null;
-		
+
 		let x = this._translate.x;
 		let y = this._translate.y;
 		let rotate = this._rotate.z;
@@ -5127,17 +5127,17 @@ var TaroEntity = TaroObject.extend({
 				!(this._category == 'projectile' && this._stats.sourceItemId == undefined && this._streamMode) // don't apply to projectiles that are CSP'ed
 			) {
 				xDiff = (finalTransform[0] - x);
-				yDiff = (finalTransform[1] - y);				
-				x = x + xDiff / 10
-	        	y = y + yDiff / 10
+				yDiff = (finalTransform[1] - y);
+				x = x + xDiff / 10;
+	        	y = y + yDiff / 10;
 	        }
 
 	        if (
 	        	// interpolate item rotation
-	        	(this._stats.controls && this._stats.controls.mouseBehaviour.rotateToFaceMouseCursor) 
+	        	(this._stats.controls && this._stats.controls.mouseBehaviour.rotateToFaceMouseCursor)
 			) {
 				rotateStart = rotate;
-	        	rotateEnd = finalTransform[2]
+	        	rotateEnd = finalTransform[2];
 	        	// a hack to prevent rotational interpolation suddnely jumping by 2 PI (e.g. 0.01 to -6.27)
 				if (Math.abs(rotateEnd - rotateStart) > Math.PI) {
 					if (rotateEnd > rotateStart) rotateStart += Math.PI * 2;
@@ -5153,46 +5153,46 @@ var TaroEntity = TaroObject.extend({
 				if (nextTransform) {
 					nextKeyFrame = [taro.nextSnapshot[0], nextTransform];
 
-					xEnd = nextTransform[0]
-					yEnd = nextTransform[1]
-					rotateEnd = nextTransform[2]
+					xEnd = nextTransform[0];
+					yEnd = nextTransform[1];
+					rotateEnd = nextTransform[2];
 				}
 			}
-			// by default, prevTransform is where this unit currently is	
+			// by default, prevTransform is where this unit currently is
 			if (taro.prevSnapshot) {
 				// Set variables up to store the previous and next data
-				var prevTransform = taro.prevSnapshot[1][this.id()];			
-				
+				var prevTransform = taro.prevSnapshot[1][this.id()];
+
 				if (prevTransform) {
 					prevKeyFrame = [taro.prevSnapshot[0], prevTransform];
-					xStart = prevTransform[0]
-					yStart = prevTransform[1]
-					rotateStart = prevTransform[2]									
-				}			
+					xStart = prevTransform[0];
+					yStart = prevTransform[1];
+					rotateStart = prevTransform[2];
+				}
 			}
 		}
 
 		// csp-projectiles are interpolated using physicsComponent-generated keyframes
 		// this is necessary, because physics don't run at 60 fps on clientside
-		if (taro.physics && this._category == 'projectile' && 
+		if (taro.physics && this._category == 'projectile' &&
 			this._stats.sourceItemId != undefined && !this._streamMode
 		) {
 			prevKeyFrame = this.prevPhysicsFrame;
 			nextKeyFrame = this.nextPhysicsFrame;
-			
+
 			var prevTransform = (this.prevPhysicsFrame) ? this.prevPhysicsFrame[1] : undefined;
 			var nextTransform = (this.nextPhysicsFrame) ? this.nextPhysicsFrame[1] : undefined;
 
 			if (prevTransform && nextTransform) {
 				if (!this.renderingStarted) this.startRendering();
-				xStart = prevTransform[0]
-				yStart = prevTransform[1]
-				xEnd = nextTransform[0]
-				yEnd = nextTransform[1]
+				xStart = prevTransform[0];
+				yStart = prevTransform[1];
+				xEnd = nextTransform[0];
+				yEnd = nextTransform[1];
 
 				if (this._category == 'projectile' && this._stats.sourceItemId != undefined && !this._streamMode) {
-					rotateStart = prevTransform[2]	
-					rotateEnd = nextTransform[2]
+					rotateStart = prevTransform[2];
+					rotateEnd = nextTransform[2];
 				}
 			}
 		}
@@ -5212,8 +5212,6 @@ var TaroEntity = TaroObject.extend({
 				prevTransform[1] = y;
 			}
 
-
-			
 			// a hack to prevent rotational interpolation suddnely jumping by 2 PI (e.g. 0.01 to -6.27)
 			if (Math.abs(rotateEnd - rotateStart) > Math.PI) {
 				if (rotateEnd > rotateStart) rotateStart += Math.PI * 2;
@@ -5221,14 +5219,12 @@ var TaroEntity = TaroObject.extend({
 			}
 
 			rotate = this.interpolateValue(rotateStart, rotateEnd, prevKeyFrame[0], taro._currentTime, nextKeyFrame[0]);
-			
 		}
-		
 
 		// ignore streamed angle if this unit control is set to face mouse cursor instantly.
 		if (this == taro.client.selectedUnit &&
-			this.angleToTarget != undefined && !isNaN(this.angleToTarget) && 
-			this._stats.controls && this._stats.controls.mouseBehaviour.rotateToFaceMouseCursor && 
+			this.angleToTarget != undefined && !isNaN(this.angleToTarget) &&
+			this._stats.controls && this._stats.controls.mouseBehaviour.rotateToFaceMouseCursor &&
 			this._stats.currentBody && !this._stats.currentBody.fixedRotation
 		) {
 			rotate = this.angleToTarget;
@@ -5237,7 +5233,7 @@ var TaroEntity = TaroObject.extend({
 		this._translate.x = x;
 		this._translate.y = y;
 		this._rotate.z = rotate;
-		// this.rotateTo(0, 0, rotate);		
+		// this.rotateTo(0, 0, rotate);
 		// this.translateTo(x, y, 0);
 		this._lastTransformAt = taro._currentTime;
 

--- a/engine/core/TaroEntity.js
+++ b/engine/core/TaroEntity.js
@@ -4709,7 +4709,7 @@ var TaroEntity = TaroObject.extend({
 					break;
 
 				case 'projectile':
-					keys = ['type', 'anim', 'stateId', 'flip'];
+					keys = ['type', 'anim', 'stateId', 'flip', 'sourceItemId'];
 					data = {
 						attributes: {},
 						// variables: {}

--- a/engine/core/TaroObject.js
+++ b/engine/core/TaroObject.js
@@ -1541,7 +1541,6 @@ var TaroObject = TaroEventingClass.extend({
 
 	update: function (ctx, tickDelta) {
 		// Check that we are alive before processing further
-
 		// if(this._category === 'regionUi') return;
 
 		if (this._alive) {

--- a/src/gameClasses/Item.js
+++ b/src/gameClasses/Item.js
@@ -364,7 +364,8 @@ var Item = TaroEntityPhysics.extend({
 													sourcePlayerId: owner.getOwner().id(),
 													unitAttributes: this._stats.damage.unitAttributes,
 													playerAttributes: this._stats.damage.playerAttributes
-												}
+												},
+												streamMode: this._stats.projectileStreamMode
 											});
 									 	var projectile = new Projectile(projectileData);
 										projectile.script.trigger('entityCreated');

--- a/src/gameClasses/Projectile.js
+++ b/src/gameClasses/Projectile.js
@@ -68,9 +68,6 @@ var Projectile = TaroEntityPhysics.extend({
 		}
 
 		this.updateBody(data.defaultData);
-		if (this._stats.streamMode === undefined) {
-			console.log(this._stats.name, ':  undefined streamMode');
-		}
 
 		if (taro.isServer) {
 			// stream projectile data if

--- a/src/gameClasses/Projectile.js
+++ b/src/gameClasses/Projectile.js
@@ -37,7 +37,7 @@ var Projectile = TaroEntityPhysics.extend({
 			self.mount(taro.$('baseScene'));
 		}
 
-		if (self._stats.sourceItemId === undefined || self._streamMode) this.startRendering();
+		if (self._stats.sourceItemId === undefined || self._stats.streamMode) this.startRendering();
 
 		if (self._stats.states) {
 			var currentState = self._stats.states[self._stats.stateId];
@@ -70,14 +70,14 @@ var Projectile = TaroEntityPhysics.extend({
 		this.updateBody(data.defaultData);
 
 		var sourceItem = this.getSourceItem();
-
+		console.log(this._stats.name, sourceItem);
 		if (taro.isServer) {
 
 			// stream projectile data if
 			if (!taro.network.isPaused && (
 					!taro.game.data.defaultData.clientPhysicsEngine || // client side isn't running physics (csp requires physics) OR
 					!sourceItem || // projectile does not have source item (created via script) OR
-					(sourceItem && sourceItem._stats.projectileStreamMode == 1) // item is set to stream its projectiles from server
+					this._stats.streamMode // item is set to stream its projectiles from server
 				)
 			) {
 				this.streamMode(1);

--- a/src/gameClasses/Projectile.js
+++ b/src/gameClasses/Projectile.js
@@ -68,15 +68,15 @@ var Projectile = TaroEntityPhysics.extend({
 		}
 
 		this.updateBody(data.defaultData);
+		if (this._stats.streamMode === undefined) {
+			console.log(this._stats.name, ':  undefined streamMode');
+		}
 
-		var sourceItem = this.getSourceItem();
-		console.log(this._stats.name, sourceItem);
 		if (taro.isServer) {
-
 			// stream projectile data if
-			if (!taro.network.isPaused && (
+			if (!taro.network.isPaused &&
+				(
 					!taro.game.data.defaultData.clientPhysicsEngine || // client side isn't running physics (csp requires physics) OR
-					!sourceItem || // projectile does not have source item (created via script) OR
 					this._stats.streamMode // item is set to stream its projectiles from server
 				)
 			) {
@@ -84,6 +84,7 @@ var Projectile = TaroEntityPhysics.extend({
 			} else {
 				this.streamMode(0);
 			}
+
 			taro.server.totalProjectilesCreated++;
 		} else if (taro.isClient) {
 			if (currentState) {

--- a/src/gameClasses/components/script/ActionComponent.js
+++ b/src/gameClasses/components/script/ActionComponent.js
@@ -1616,7 +1616,6 @@ var ActionComponent = TaroEntity.extend({
 						break;
 
 					/* projectile */
-
 					case 'createProjectileAtPosition':
 						var projectileTypeId = self._script.variable.getValue(action.projectileType, vars);
 						var position = self._script.variable.getValue(action.position, vars);
@@ -1652,13 +1651,14 @@ var ActionComponent = TaroEntity.extend({
 												x: Math.cos(angle) * force,
 												y: Math.sin(angle) * force
 											}
-										}
+										},
+										streamMode: 1
 									}
 								);
 
 								var projectile = new Projectile(data);
 								taro.game.lastCreatedProjectileId = projectile._id;
-								projectile.script.trigger("entityCreated");
+								projectile.script.trigger('entityCreated');
 							} else {
 								if (!projectileData) {
 									self._script.errorLog('invalid projectile data');


### PR DESCRIPTION
#### changelog

- modernize `this._streamMode` to `this._stats.streamMode` due to `this.streamMode` moving entirely within server logic
- fix all conditions that use `streamMode` to decide which stream to update from
- remove 'sourceItem' checks that used to be for determining script-created projectiles but are now defunct
- make sure that projectiles have a `streamMode` setting no matter where they are created from.

This should re-enable server-streamed projectiles.

#### issues

- setting grenade to `streamMode = 0` rarely has invisible projectile [CSP]
- similar behaviour when `ignoreServerStream = true` [CSP]

These issues appear to be unrelated to this PR.