### PR TITLE
Fix physics timestep

### DIFF
--- a/engine/core/TaroEngine.js
+++ b/engine/core/TaroEngine.js
@@ -71,7 +71,7 @@ var TaroEngine = TaroEntity.extend({
 		if (this.isServer) {
 			// this._idCounter = 0
 			this.sanitizer = require('sanitizer').sanitize;
-			this.emptyTimeLimit = 10 * 60 * 1000; // in ms - kill t1/t2 if empty for 10 mins			
+			this.emptyTimeLimit = 10 * 60 * 1000; // in ms - kill t1/t2 if empty for 10 mins
 		}
 
 		// Setup components
@@ -109,6 +109,9 @@ var TaroEngine = TaroEntity.extend({
 		this._lastGameLoopTickAt = 0;
 		this._gameLoopTickRemainder = 0;
 		this.gameLoopTickHasExecuted = true;
+
+		this.accumulator = 0;
+		this.lastMsElapsed = Date.now();
 
 		this._aSecondAgo = 0;
 
@@ -1495,6 +1498,25 @@ var TaroEngine = TaroEntity.extend({
 		this.triggersQueued.push({name: triggerName, params: parameters});
 	},
 
+	// physics tick (fixed time step)
+	physicsStep: function() {
+		// calculate delta time
+		const msElapsed = taro.now - this.lastMsElapsed;
+		this.lastMsElapsed = taro.now;
+		const delta = msElapsed / 1000;
+
+		// calculate timestep
+		const frameTime = Math.min(delta, 0.25); // max frame time to avoid spiral of death (on slow devices)
+		this.accumulator += frameTime;
+		const timeStep = 1.0 / taro.game.data.defaultData.frameRate;
+
+		// step physics
+		while (this.accumulator >= timeStep) {
+			taro.physics.update(timeStep * 1000);
+			this.accumulator -= timeStep;
+		}
+	},
+
 	/**
 	 * Called each frame to traverse and render the scenegraph.
 	 */
@@ -1569,12 +1591,11 @@ var TaroEngine = TaroEntity.extend({
 				taro._lastGameLoopTickAt = taro.now;
 				taro._gameLoopTickRemainder = Math.min(timeElapsed - ((1000 / taro._gameLoopTickRate) - taro._gameLoopTickRemainder), (1000 / taro._gameLoopTickRate));
 				taro.gameLoopTickHasExecuted = true;
-				if (taro.physics) {
-					taro.physics.update(timeElapsed);
-				}
 
 				taro.queueTrigger('frameTick');
 			}
+
+			self.physicsStep();
 
 			taro.tickCount = 0;
 			taro.updateTransform = 0;
@@ -1631,7 +1652,7 @@ var TaroEngine = TaroEntity.extend({
 
 						if (typeof window.raidAlert === 'function') {
 							window.raidAlert()
-						}							
+						}
 					}
 				} else if (taro.isServer) {
 					if (playerCount <= 0) {
@@ -2178,7 +2199,7 @@ var TaroEngine = TaroEntity.extend({
 			return player._stats.controlledBy == 'human';
 		}).length;
 	},
-	
+
 	devLog: function () {
 		// return;
 		// if (taro.env == 'local') {


### PR DESCRIPTION
• Fixes physics ticks per second always running at 20 ticks per second
• Uses fixed timestep to avoid unpredictable physics stepping at variable updates

Note:

• Does not implement delta timer for other physics operations (velocity etc), so if creators change the physics rate, they have to change other things like movement speed etc.
• Resolves https://trello.com/c/AigAP26I/8792-fix-physics-updates-per-second-game-setting-not-actually-working