### PR TITLE
Scoreboard UI id and class

### DIFF
--- a/src/gameClasses/components/ui/ScoreboardComponent.js
+++ b/src/gameClasses/components/ui/ScoreboardComponent.js
@@ -172,6 +172,7 @@ var ScoreboardComponent = TaroEntity.extend({
 				var defaultFontWeight = 500;
 				if (player) {
 					var color = null; // color to indicate human, animal, or my player on scoreboard
+					let playerIsSelf = '';
 
 					var playerType = taro.game.getAsset('playerTypes', player._stats.playerTypeId);
 
@@ -183,6 +184,7 @@ var ScoreboardComponent = TaroEntity.extend({
 					if (player._stats.controlledBy == 'human' && player._stats.clientId == taro.network.id()) {
 						defaultFontWeight = 800;
 						color = '#99FF00';
+						playerIsSelf = 'scoreboard-player-is-myself';
 					}
 
 					var readableName = player._stats.name || '';
@@ -191,7 +193,11 @@ var ScoreboardComponent = TaroEntity.extend({
 					readableName = readableName.replace(/>/g, '&gt;');
 
 					color = color || DEFAULT_COLOR;
-					scoreboard += `<div onContextMenu="window.showUserDropdown({ event, userId: '${player._stats.userId}' })" class='cursor-pointer scoreboard-user-entry' style='color: ${color};font-weight:${defaultFontWeight}'>${readableName} <small><span>${self.convertNumbersToKMB(sortedScores[i].value)}</span></small></div>`;
+					scoreboard += `
+						<div onContextMenu="window.showUserDropdown({ event, userId: '${player._stats.userId}' })" class='cursor-pointer scoreboard-user-entry scoreboard-player-rank-${i} ${playerIsSelf}' style='color: ${color};font-weight:${defaultFontWeight}'>
+							<span class='scoreboard-player-name'>${readableName}</span> <small class='scoreboard-player-score'><span>${self.convertNumbersToKMB(sortedScores[i].value)}</span></small>
+						</div>
+					`;
 				}
 			}
 

--- a/src/templates/gui.ejs
+++ b/src/templates/gui.ejs
@@ -7,7 +7,7 @@
         <u id="leaderboard-title" class="cursor-pointer" onclick="taro.scoreboard && taro.scoreboard.toggleScores()">Leaderboard</u>
         <div id="leaderboard-toggle" style="display: inline" class="pull-right"></div>
     </span>
-    <div id="scoreboard" class="pull-right" style="padding: 10px 19px 0px 0px"></div>
+    <div id="scoreboard" style="padding: 10px 19px 0px 0px"></div>
 </div>
 
 <!-- player attribute -->


### PR DESCRIPTION
More Id and class added to scoreboard UI
![image](https://github.com/moddio/taro2/assets/62375288/a9a50b26-62ec-4ff5-a83f-2fb57be50144)

Some use case on it
- Use #scoreboard-player-rank-0 , 1, 2 to set displaying color to gold, silver, bronze to represent top 3
- Use .scoreboard-player-is-myself to override the green color of self owned player with { color: <some color> !important; }
And more!

Also the pull-right thing in gui.ejs makes local host environment having the leaderboard displayed kinda buggy so it is removed