### PR TITLE
Fix unintentional mouse click event

### DIFF
--- a/engine/components/TaroInputComponent.js
+++ b/engine/components/TaroInputComponent.js
@@ -268,7 +268,7 @@ var TaroInputComponent = TaroEventingClass.extend({
 		};
 
 		// Listen for mouse events
-		window.addEventListener('mousedown', this._evRef.mousedown, false);
+		canvas.addEventListener('mousedown', this._evRef.mousedown, false);
 		window.addEventListener('mouseup', this._evRef.mouseup, false);
 
 		canvas.addEventListener('mousemove', this._evRef.mousemove, false);


### PR DESCRIPTION
This can avoid mouseDown event received unintentionally when clicking some other div
Solving this: https://trello.com/c/SCEelIw3/8970-clicking-on-editor-elements-often-triggers-item-use

### Tested with this:
[game.txt](https://github.com/moddio/taro2/files/12216145/game.txt)

It will apply you some velocity when you have mouseUp
Apparently not affecting anything, taro will only execute mouse up abilities if you ever mouseDown