### PR TITLE
do not create particles when the tab is not active

### DIFF
--- a/src/gameClasses/ClientNetworkEvents.js
+++ b/src/gameClasses/ClientNetworkEvents.js
@@ -553,15 +553,17 @@ var ClientNetworkEvents = {
 	},
 
 	_onParticle: function (data) {
-		var particleData = taro.game.data.particleTypes[data.particleId];
-		if (particleData) {
-			if (data.entityId) {
-				if (taro.client.entityUpdateQueue[data.entityId] == undefined) {
-					taro.client.entityUpdateQueue[data.entityId] = [];
+		if (taro.client.isActiveTab) {
+			var particleData = taro.game.data.particleTypes[data.particleId];
+			if (particleData) {
+				if (data.entityId) {
+					if (taro.client.entityUpdateQueue[data.entityId] == undefined) {
+						taro.client.entityUpdateQueue[data.entityId] = [];
+					}
+					taro.client.entityUpdateQueue[data.entityId].push({ particle: data });
+				} else {
+					taro.client.emit("create-particle", data);
 				}
-				taro.client.entityUpdateQueue[data.entityId].push({ particle: data });
-			} else {
-				taro.client.emit("create-particle", data);
 			}
 		}
 	},


### PR DESCRIPTION
when the player switches tabs and comes back all the particles seem to be created at once, causing the client to freeze