### PR TITLE
New bool comparison isPlayerPlayingWithMobile

### DIFF
--- a/engine/components/network/net.io/net.io-client/index.js
+++ b/engine/components/network/net.io/net.io-client/index.js
@@ -113,7 +113,7 @@ NetIo.Client = NetIo.EventingClass.extend({
 		var posthogDistinctId = window.posthogDistinctId || (window.posthog && window.posthog.get_distinct_id ? window.posthog.get_distinct_id() : '');	
 		const workerPortQuery = (new URL(window.location.href).searchParams.get('proxy') === 'master') ? '' : `&cfwp=${(parseInt(taro.client.server?.name?.split('.')[1] || 0) + 2000)}`;
 		
-		this.wsUrl = `${url}?token=${gsAuthToken}&sid=${taro.client.server.id}${workerPortQuery}&distinctId=${distinctId}&posthogDistinctId=${posthogDistinctId}`;
+		this.wsUrl = `${url}?token=${gsAuthToken}&sid=${taro.client.server.id}${workerPortQuery}&distinctId=${distinctId}&posthogDistinctId=${posthogDistinctId}&isMobile=${(taro.isMobile ? 1 : 0)}`;
 		this.wsStartTime = Date.now();
 		this.startTimeSinceLoad = performance.now();
 

--- a/engine/components/network/net.io/net.io-server/index.js
+++ b/engine/components/network/net.io/net.io-server/index.js
@@ -824,6 +824,7 @@ NetIo.Server = NetIo.EventingClass.extend({
 					sessionId: decodedToken.sessionId,
 					distinctId : searchParams.get('distinctId'),
 					posthogDistinctId : searchParams.get('posthogDistinctId'),
+					isMobile: searchParams.get('isMobile'),
 					token,
 					tokenCreatedAt: decodedToken.createdAt
 				};
@@ -941,7 +942,8 @@ NetIo.Server = NetIo.EventingClass.extend({
 				number: (Math.floor(Math.random() * 999) + 100),
 				_id: socket._token.userId,
 				sessionId: socket._token.sessionId,
-				isAdBlockEnabled: false
+				isAdBlockEnabled: false,
+				isMobile: socket._token.isMobile
 			};
 			const clientId = socket.id;
 
@@ -981,7 +983,8 @@ NetIo.Server = NetIo.EventingClass.extend({
 					number: (Math.floor(Math.random() * 999) + 100),
 					_id: socket._token.userId,
 					sessionId: socket._token.sessionId,
-					isAdBlockEnabled: false
+					isAdBlockEnabled: false,
+					isMobile: socket._token.isMobile
 				};
 
 				const clientId = socket.id;

--- a/server/ServerNetworkEvents.js
+++ b/server/ServerNetworkEvents.js
@@ -157,9 +157,7 @@ var ServerNetworkEvents = {
 			return;
 		}
 
-		if (data.isMobile) {
-			data.isMobile = (data.isMobile == '1') ? true : false;
-		}
+		data.isMobile = (data.isMobile && data.isMobile == '1');
 
 		// if user is logged-in
 		if (data && data._id) {

--- a/server/ServerNetworkEvents.js
+++ b/server/ServerNetworkEvents.js
@@ -157,6 +157,10 @@ var ServerNetworkEvents = {
 			return;
 		}
 
+		if (data.isMobile) {
+			data.isMobile = (data.isMobile == '1') ? true : false;
+		}
+
 		// if user is logged-in
 		if (data && data._id) {
 			// if player already exists in the game
@@ -180,6 +184,7 @@ var ServerNetworkEvents = {
 			if (player && clientId == player._stats.clientId) {
 				console.log('Player requested to join game ' + clientId + ' (' + player._stats.name + ')');
 				player._stats.isAdBlockEnabled = data.isAdBlockEnabled;
+				player._stats.isMobile = data.isMobile;
 				player.joinGame();
 			}
 			else {
@@ -229,6 +234,7 @@ var ServerNetworkEvents = {
 
 				if (player) {
 					player._stats.isAdBlockEnabled = data.isAdBlockEnabled;
+					player._stats.isMobile = data.isMobile;
 				} else {
 					if (typeof data.number != 'number') {
 						data.number = ' lol';
@@ -241,7 +247,8 @@ var ServerNetworkEvents = {
 						coins: 0,
 						points: 0,
 						clientId: clientId,
-						isAdBlockEnabled: data.isAdBlockEnabled
+						isAdBlockEnabled: data.isAdBlockEnabled,
+						isMobile: data.isMobile
 					});
 				}
 

--- a/src/gameClasses/components/GameComponent.js
+++ b/src/gameClasses/components/GameComponent.js
@@ -76,6 +76,7 @@ var GameComponent = TaroEntity.extend({
 			lastPlayed: data.lastPlayed,
 			userId: data._id,
 			isAdBlockEnabled: data.isAdBlockEnabled,
+			isMobile: data.isMobile,
 			unitIds: [], // all units owned by player,
 			jointsOn: Date.now(), // use for calculating session,
 			totalTime: data.totalTime,

--- a/src/gameClasses/components/script/VariableComponent.js
+++ b/src/gameClasses/components/script/VariableComponent.js
@@ -280,7 +280,13 @@ var VariableComponent = TaroEntity.extend({
 					var roleId = role && role._id;
 					
 					returnValue = roleId && player && (player._stats.roleIds || []).includes(roleId);	
-					break;				
+					break;
+
+				case 'isPlayerPlayWithMobile':
+					var player = self._script.variable.getValue(text.player, vars);
+					returnValue = player && player._stats.isMobile;
+					
+					break;
 
 				case 'areEntitiesTouching':
 					var sourceEntity = self.getValue(text.sourceEntity, vars);


### PR DESCRIPTION
This new bool comparison allow creators to know if a player use mobile or not

## Use of test
[game.txt](https://github.com/moddio/taro2/files/12225213/game.txt)
It will display a fading text on the unit whether the owner of that unit is using mobile.

### Player that use computer
![image](https://github.com/moddio/taro2/assets/62375288/0d0c47ff-b7a9-4af1-9676-4939f357968b)
### Player that use mobile
![image](https://github.com/moddio/taro2/assets/62375288/1936e0e0-986f-4921-9db8-7a90a1f8cf9e)



## Use case example
- Customize Mobile interaction to better fit their needs (e.g. some mouse cursor position event could be changed to mouse click event for mobile by the creator)
- Change camera zoom for mobile
- Change dialogue to be show to mobile player (Reduce the difficulty for creators to use handlebar.js)